### PR TITLE
order types mod update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,20 @@ name = "archiver"
 name = "api"
 
 [dependencies]
-bigdecimal = { version = "0.3.1", features = ["serde"] }
+bigdecimal = { version = "0.4.1", features = ["serde"] }
 bincode = "1.3"
 chrono = { version = "0.4.23", features = ["clock", "serde"] }
 crossbeam-channel = "0.5.6"
-diesel = { version = "2.0.2", features = ["uuid", "bigdecimal", "chrono", "numeric", "postgres_backend", "postgres", "r2d2", "serde_json"] }
+diesel = { version = "2.0.2", features = [
+    "uuid",
+    "bigdecimal",
+    "chrono",
+    "numeric",
+    "postgres_backend",
+    "postgres",
+    "r2d2",
+    "serde_json",
+] }
 diesel_migrations = { version = "2.0.0", features = ["postgres"] }
 digest = "0.10.7"
 dotenv = "0.15.0"
@@ -27,7 +36,12 @@ hmac = "0.12.1"
 http = "0.2"
 http-body = "0.4"
 hyper = "0.14.26"
-jsonrpsee = { version = "0.16.2", features = ["server", "client", "jsonrpsee-core", "macros"] }
+jsonrpsee = { version = "0.16.2", features = [
+    "server",
+    "client",
+    "jsonrpsee-core",
+    "macros",
+] }
 jwt = "0.16.0"
 kafka = "0.9.0"
 log = "0.4.17"
@@ -40,9 +54,14 @@ thiserror = "1.0.38"
 tokio = { version = "1.24.1", features = ["rt-multi-thread", "macros"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tower = { version = "0.4", features = ["make", "util"] }
-tower-http = { version = "0.4", features = ["auth", "cors", "sensitive-headers", "validate-request"] }
+tower-http = { version = "0.4", features = [
+    "auth",
+    "cors",
+    "sensitive-headers",
+    "validate-request",
+] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
-twilight-relayer-rust = { git = "ssh://git@github.com/twilight-project/twilight-relayer.git", branch = "zkos-0.02-wallet" }
+twilight-relayer-rust = { git = "ssh://git@github.com/twilight-project/twilight-relayer.git", branch = "zkos-0.03-rpccommnd-updates" }
 zkos-client-wallet = { git = "ssh://git@github.com/twilight-project/zkos-client-wallet.git", branch = "develop" }
 zkos-relayer-wallet = { git = "ssh://git@github.com/twilight-project/zkos-relayer-wallet.git", branch = "develop" }
 uuid = { version = "1.3.3", features = ["serde", "v4", "v7"] }

--- a/src/database/sql_types.rs
+++ b/src/database/sql_types.rs
@@ -12,10 +12,10 @@ use diesel::{
     pg::Pg,
     serialize::{self, IsNull, Output, ToSql},
 };
+use relayerwalletlib::zkoswalletlib::relayer_types;
 use serde::{Deserialize, Serialize};
 use std::io::Write;
 use twilight_relayer_rust::relayer;
-use zkoswalletlib::relayer_types;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum TXType {

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -13,8 +13,8 @@
 // •	Server Time
 use crate::auth::UserInfo;
 use chrono::prelude::*;
+use relayerwalletlib::zkoswalletlib::relayer_types::{OrderStatus, OrderType, PositionType};
 use serde::{Deserialize, Serialize};
-use zkoswalletlib::relayer_types::{OrderStatus, OrderType, PositionType};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RpcArgs<T> {

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -7,6 +7,7 @@ use diesel::prelude::PgConnection;
 use diesel::r2d2::ConnectionManager;
 use jsonrpsee::RpcModule;
 use log::{error, info, trace};
+use relayerwalletlib::zkoswalletlib::relayer_types::{OrderStatus, OrderType};
 use serde::{Deserialize, Serialize};
 use std::time::{Duration, Instant};
 use tokio::{
@@ -14,7 +15,6 @@ use tokio::{
     task::JoinHandle,
 };
 use twilight_relayer_rust::{db::Event, relayer};
-use zkoswalletlib::relayer_types::{OrderStatus, OrderType};
 
 mod methods;
 


### PR DESCRIPTION
cargo toml update with latest relayer branch
relayer types changed from zkoswalletlib to relayerwalletlib as we need to import only from realyer wallet and no direct import from clientwallet in relayer or API